### PR TITLE
XMPL CDN Version 4.1 to 5

### DIFF
--- a/Sample sites/xmpl-jquery/content.html
+++ b/Sample sites/xmpl-jquery/content.html
@@ -13,7 +13,7 @@
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 		<!-- XMPie XMPL library -->
 		<script src="./xmpcfg.js"></script>
-		<script src="https://ajax.xmcircle.com/ajax/libs/XMPL-NG/4.1/xmpl.min.js"></script>
+		<script src="https://ajax.xmcircle.com/ajax/libs/XMPL-V5/5.0/xmpl.min.js"></script>
 	</head>
 	<body class="is-preload" xmp-personalized-controller
 		xmp-cloak

--- a/Sample sites/xmpl-jquery/index.html
+++ b/Sample sites/xmpl-jquery/index.html
@@ -13,7 +13,7 @@
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 		<!-- XMPie XMPL library -->
 		<script src="./xmpcfg.js"></script>
-		<script src="https://ajax.xmcircle.com/ajax/libs/XMPL-NG/4.1/xmpl.min.js"></script>
+		<script src="https://ajax.xmcircle.com/ajax/libs/XMPL-V5/5.0/xmpl.min.js"></script>
 	</head>
 	<body class="is-preload" xmp-personalized-controller
       xmp-cloak


### PR DESCRIPTION
changing the header's link from v4.1 to v5 in index.html and content.html under jQuery Sample